### PR TITLE
[DOI-1221] Display Automation donut chart by total sales amount

### DIFF
--- a/src/components/AssistedShopping/index.js
+++ b/src/components/AssistedShopping/index.js
@@ -291,11 +291,13 @@ const getAutomationDonutData = (assistedSales) => {
         order.campaign["automationEventType"],
         {
           key: order.campaign.automationEventType,
-          value: assistedSales.filter((sale) =>
-            sale.campaign.automationEventType.includes(
-              order.campaign.automationEventType,
-            ),
-          ).length,
+          value: assistedSales
+            .filter((sale) =>
+              sale.campaign.automationEventType.includes(
+                order.campaign.automationEventType,
+              ),
+            )
+            .reduce((a, v) => a + v.orderTotal, 0),
         },
       ]),
     ).values(),


### PR DESCRIPTION
Changes how the automation chart is calculated, instead of using the amount of sales it is now using the total sales amount.