### PR TITLE
Do not use hidenavbar function, send rfm ready

### DIFF
--- a/src/components/Rfm/index.jsx
+++ b/src/components/Rfm/index.jsx
@@ -5,9 +5,6 @@ import { useUpdateRfmSettings } from "../../queries/doppler-legacy-queries";
 import { useGetIntegrationStatus } from "../../queries/integrations-api-queries";
 import Button from "../ui/Button";
 import { LoadingScreen } from "../application";
-import { hideNavBar } from "../../utils";
-
-hideNavBar();
 
 export const RFM = ({ integration, idThirdPartyApp }) => {
   const intl = useIntl();
@@ -27,6 +24,11 @@ export const RFM = ({ integration, idThirdPartyApp }) => {
     active: false,
     period: 120,
   });
+
+  useEffect(() => {
+    window.displayDopplerNavBar(false);
+    window.parent.postMessage({ type: "rfmReady" }, "*");
+  }, []);
 
   const { mutate: updateRfmSettings, isLoading: updatingMutation } =
     useUpdateRfmSettings();

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -78,12 +78,3 @@ export const sanitizeDateStringToIsoFormat = (dateString: string) => {
 
 export const capitalize = (text: string): string =>
   text ? text.charAt(0).toUpperCase() + text.slice(1) : "";
-
-export function hideNavBar(): void {
-  const intervalId = setInterval(() => {
-    if (window.displayDopplerNavBar) {
-      window.displayDopplerNavBar(false);
-      clearInterval(intervalId);
-    }
-  }, 50);
-}


### PR DESCRIPTION
Se descontinua el uso de la función `hideNavBar` que había creado ya que no es útil y no es eficaz el 100% de las veces, a su vez se estaba usando de manera global afectando a la vista de Ventas Asistidas. Ahora se usa directamente la función `window.displayDopplerNavBar(false);` en un useEffect, cuando la vista termina de realizar esta acción se le notifica al padre que lo renderiza (webapp) con un objeto `rfmReady` que le permite saber cuando renderizar.

[PR webapp](https://github.com/FromDoppler/doppler-webapp/pull/2718)